### PR TITLE
Add support for impersonating service account from other service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ locals {
         project: bulder-yolo-swag
         roles:
           - roles/secretmanager.objectAdmin
+      # Example: Impersonate service account in other project
+      - type: impersonation
+        name: some-service-account
+        project: different-project
+        roles:
+          - roles/placeholder.role # Hax to make GSA module apply the impersonation
   EOT
   )
 }
@@ -48,7 +54,7 @@ locals {
 module "gsa" {
   source = <path to this module>
   for_each = local.example
-  
+
   account_id = each.key
   project = "some-project"
   iam_roles = each.value

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,17 @@ resource "google_folder_iam_member" "env" {
   member = "serviceAccount:${google_service_account.env.email}"
 }
 
+resource "google_service_account_iam_binding" "env" {
+  for_each = {
+    for k, v in local.iam_roles : k => v
+    if v.type == "impersonation"
+  }
+
+  service_account_id = "projects/${each.value.project}/serviceAccounts/${each.value.name}@${each.value.project}.iam.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members            = ["serviceAccount:${google_service_account.env.email}"]
+}
+
 output "email" {
   value = google_service_account.env.email
 }


### PR DESCRIPTION
This adds the possibility to use service account impersonation in terraform, meaning that one service account can assume another service account and perform actions as this assumed identity.
```
        tf-your-service-account:
          - type: impersonation
            name: name-of-service-account-to-impersonate
            project: project-of-service-account-to-impersonate
            roles:
              - roles/placeholder.role # Hax to make gsa module apply this impersonation
```

Ideally, the role list should not be needed, but because of the construction of the terraform module an empty list would make the module ignore the config.