### PR TITLE
Change impersonation to use iam_member instead of iam_binding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "google_folder_iam_member" "env" {
   member = "serviceAccount:${google_service_account.env.email}"
 }
 
-resource "google_service_account_iam_binding" "env" {
+resource "google_service_account_iam_member" "env" {
   for_each = {
     for k, v in local.iam_roles : k => v
     if v.type == "impersonation"
@@ -90,7 +90,7 @@ resource "google_service_account_iam_binding" "env" {
 
   service_account_id = "projects/${each.value.project}/serviceAccounts/${each.value.name}@${each.value.project}.iam.gserviceaccount.com"
   role               = "roles/iam.serviceAccountTokenCreator"
-  members            = ["serviceAccount:${google_service_account.env.email}"]
+  member             = "serviceAccount:${google_service_account.env.email}"
 }
 
 output "email" {


### PR DESCRIPTION
Use iam_member instead of iam_binding for service account impersonation as we need to have more than one.